### PR TITLE
Add Translate Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -316,6 +316,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -943,6 +944,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -983,6 +985,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -1612,6 +1615,7 @@
             "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -2819,6 +2823,7 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -2841,6 +2846,7 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
             "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -2959,6 +2965,7 @@
             "integrity": "sha512-PsSugIf9ip1H/mWKj4bi/BlEoerxXAda9ByRFsYuwsmr6af9NxJL0AaiNXs8Le7R21QR5KMiD/KdxZZ71LjAxQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/types": "^8.52.0",
@@ -2991,6 +2998,7 @@
             "resolved": "https://registry.npmjs.org/@textcomplete/core/-/core-0.1.13.tgz",
             "integrity": "sha512-C4S+ihQU5HsKQ/TbsmS0e7hfPZtLZbEXj5NDUgRnhu/1Nezpu892bjNZGeErZm+R8iyDIT6wDu6EgIhng4M8eQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "eventemitter3": "^5.0.1"
             }
@@ -3081,6 +3089,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
             "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -3339,6 +3348,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3406,6 +3416,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -4222,6 +4233,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@popperjs/core": "^2.11.8"
             }
@@ -4288,6 +4300,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -6644,6 +6657,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6766,6 +6780,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -7103,6 +7118,7 @@
             "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
             "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cookie": "0.7.2",
                 "cookie-signature": "1.0.7",
@@ -9903,7 +9919,8 @@
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
             "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jquery-deserialize": {
             "version": "2.0.0",
@@ -11432,6 +11449,7 @@
             "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
             "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@mongodb-js/saslprep": "^1.3.0",
                 "bson": "^7.0.0",
@@ -13246,6 +13264,7 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",
@@ -13500,6 +13519,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -14362,6 +14382,7 @@
             "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
             "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@redis/bloom": "5.10.0",
                 "@redis/client": "5.10.0",
@@ -14403,6 +14424,7 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.5.6.tgz",
             "integrity": "sha512-M3Svdwt6oSfyfQdqEr0L2HOJH2vK7GgCFx1NfAQvpWAT4+ljoT1L5S5cKT3dA9NJrxrOPDkdoTPWJnIrGCOcmw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -15409,6 +15431,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15920,6 +15943,7 @@
             "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
             "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "~4.4.1",
                 "ws": "~8.18.3"
@@ -16048,6 +16072,7 @@
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
@@ -17592,6 +17617,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
             "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -305,5 +305,7 @@
 	"activitypub.pubKey-not-found": "Unable to resolve public key, so payload verification cannot take place.",
 	"activitypub.origin-mismatch": "The received object's origin does not match the sender's origin",
 	"activitypub.actor-mismatch": "The received activity is being carried out by an actor that is different from expected.",
-	"activitypub.not-implemented": "The request was denied because it or an aspect of it is not implemented by the recipient server"
+	"activitypub.not-implemented": "The request was denied because it or an aspect of it is not implemented by the recipient server",
+
+	"translation-service-unavailable": "Translation service is currently unavailable. Please try again later."
 }

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -46,6 +46,10 @@
 	"copy-ip": "Copy IP",
 	"ban-ip": "Ban IP",
 	"view-history": "Edit History",
+	"translate": "Translate",
+	"show-original": "Show Original",
+	"already-english": "This post is already in English.",
+	"translation-failed": "Translation failed. Please try again later.",
 
 	"wrote-ago": "wrote <a href=\"%1\" class=\"timeago text-muted\" title=\"%2\"></a>",
 	"wrote-on": "wrote on <a href=\"%1\" class=\"timeago text-muted\" title=\"%2\"></a>",

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -80,15 +80,45 @@ define('forum/topic', [
 	};
 
 	function configurePostToggle() {
-		$('.topic').on('click', '.view-translated-btn', function () {
-			// Toggle the visibility of the next .translated-content div
-			$(this).closest('.sensitive-content-message').next('.translated-content').toggle();
-			// Optionally, change the button text based on visibility
-			var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
-			if (isVisible) {
-				$(this).text('Hide the translated message.');
-			} else {
-				$(this).text('Click here to view the translated message.');
+		$('.topic').on('click', '.view-translated-btn', async function () {
+			const btn = $(this);
+			const postEl = btn.closest('[data-pid]');
+			const pid = postEl.attr('data-pid');
+			const contentEl = postEl.find('[component="post/content"]');
+
+			if (contentEl.attr('data-translated') === 'true') {
+				contentEl.html(contentEl.attr('data-original-html'));
+				contentEl.removeAttr('data-translated');
+				btn.text('Click here to view the translated message.');
+				return;
+			}
+
+			btn.prop('disabled', true);
+			btn.text('Translating... this may take a few minutes');
+			try {
+				const result = await fetch(config.relative_path + '/api/v3/posts/' + pid + '/translate', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json', 'x-csrf-token': config.csrf_token },
+					body: JSON.stringify({}),
+				});
+				const data = await result.json();
+				if (data.status && data.status.code === 'ok' && data.response) {
+					if (data.response.translated && data.response.content) {
+						contentEl.attr('data-original-html', contentEl.html());
+						contentEl.attr('data-translated', 'true');
+						contentEl.html('<p>' + $('<div>').text(data.response.content).html() + '</p>');
+						btn.text('Hide the translated message.');
+					} else {
+						btn.text('Post is already in English.');
+						setTimeout(function () { btn.text('Click here to view the translated message.'); }, 3000);
+					}
+				} else {
+					btn.text('Translation failed. Click to retry.');
+				}
+			} catch (err) {
+				btn.text('Translation failed. Click to retry.');
+			} finally {
+				btn.prop('disabled', false);
 			}
 		});
 	}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -305,8 +305,11 @@ define('forum/topic/postTools', [
 			}
 
 			btn.prop('disabled', true);
+			const loadingEl = $('<p class="text-muted"><i class="fa fa-spinner fa-spin"></i> Translating... this may take a few minutes</p>');
+			contentEl.append(loadingEl);
 			try {
 				const result = await api.post(`/posts/${encodeURIComponent(pid)}/translate`, {});
+				loadingEl.remove();
 				if (result && result.translated && result.content) {
 					contentEl.attr('data-original-html', contentEl.html());
 					contentEl.attr('data-translated', 'true');
@@ -322,6 +325,7 @@ define('forum/topic/postTools', [
 					});
 				}
 			} catch (err) {
+				loadingEl.remove();
 				alerts.error(err);
 			} finally {
 				btn.prop('disabled', false);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -289,6 +289,45 @@ define('forum/topic/postTools', [
 		postContainer.on('click', '[component="post/chat"]', function () {
 			openChat($(this));
 		});
+
+		postContainer.on('click', '[component="post/translate"]', async function () {
+			const btn = $(this);
+			const pid = getData(btn, 'data-pid');
+			const postEl = btn.parents('[data-pid]');
+			const contentEl = postEl.find('[component="post/content"]');
+
+			// If already translated, toggle back to original
+			if (contentEl.attr('data-translated') === 'true') {
+				contentEl.html(contentEl.attr('data-original-html'));
+				contentEl.removeAttr('data-translated');
+				contentEl.removeAttr('data-original-html');
+				return false;
+			}
+
+			btn.prop('disabled', true);
+			try {
+				const result = await api.post(`/posts/${encodeURIComponent(pid)}/translate`, {});
+				if (result && result.translated && result.content) {
+					contentEl.attr('data-original-html', contentEl.html());
+					contentEl.attr('data-translated', 'true');
+					const escaped = $('<div>').text(result.content).html();
+					contentEl.html('<p>' + escaped + '</p>');
+				} else if (result && !result.translated) {
+					alerts.alert({
+						alert_id: 'translate_' + pid,
+						title: '[[topic:translate]]',
+						message: '[[topic:already-english]]',
+						type: 'info',
+						timeout: 5000,
+					});
+				}
+			} catch (err) {
+				alerts.error(err);
+			} finally {
+				btn.prop('disabled', false);
+			}
+			return false;
+		});
 	}
 
 	async function onReplyClicked(button, tid) {

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -708,7 +708,7 @@ postsAPI.translate = async function (caller, data) {
 		console.log('[translate] Flask result:', JSON.stringify(result));
 	} catch (err) {
 		console.error('[translate] Error:', err.message);
-		throw new Error('[[error:translation-service-unavailable]]');
+		return { translated: false, content: postData, original: postData };
 	}
 
 	return {

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -694,17 +694,20 @@ postsAPI.translate = async function (caller, data) {
 
 	let result;
 	try {
+		console.log('[translate] Calling Flask with content:', postData);
 		const response = await fetch('http://localhost:5001/translate', {
 			method: 'POST',
 			headers: { 'content-type': 'application/json' },
 			body: JSON.stringify({ content: postData }),
-			signal: AbortSignal.timeout(30000),
 		});
+		console.log('[translate] Flask response status:', response.status);
 		if (!response.ok) {
 			throw new Error(`Microservice returned status ${response.status}`);
 		}
 		result = await response.json();
+		console.log('[translate] Flask result:', JSON.stringify(result));
 	} catch (err) {
+		console.error('[translate] Error:', err.message);
 		throw new Error('[[error:translation-service-unavailable]]');
 	}
 

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -691,9 +691,26 @@ postsAPI.changeOwner = async function (caller, data) {
 
 postsAPI.translate = async function (caller, data) {
 	const postData = await posts.getPostField(data.pid, 'content');
+
+	let result;
+	try {
+		const response = await fetch('http://localhost:5001/translate', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ content: postData }),
+			signal: AbortSignal.timeout(30000),
+		});
+		if (!response.ok) {
+			throw new Error(`Microservice returned status ${response.status}`);
+		}
+		result = await response.json();
+	} catch (err) {
+		throw new Error('[[error:translation-service-unavailable]]');
+	}
+
 	return {
-		translated: true,
-		content: 'This is a hardcoded translation for now.',
+		translated: !result.is_english,
+		content: result.translated_content,
 		original: postData,
 	};
 };

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -51,7 +51,7 @@ module.exports = function () {
 
 	// Shorthand route to access post routes by topic index
 	router.all('/+byIndex/:index*?', [middleware.checkRequired.bind(null, ['tid'])], controllers.write.posts.redirectByIndex);
-	setupApiRoute(router, 'post', '/:pid/translate', [middleware.assert.post], controllers.write.posts.translate);
+	setupApiRoute(router, 'post', '/:pid/translate', [middleware.ensureLoggedIn, middleware.assert.post], controllers.write.posts.translate);
 
 	return router;
 

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -125,6 +125,14 @@
 	</li>
 {{{ end }}}
 
+{{{ if config.loggedIn }}}
+<li>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/translate" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-language"></i></span> [[topic:translate]]
+	</a>
+</li>
+{{{ end }}}
+
 {{{ if posts.display_flag_tools }}}
 <li class="dropdown-divider"></li>
 


### PR DESCRIPTION
**Add Translate Endpoint**
Integrates the translation feature into NodeBB, connecting the frontend translate button to the Flask microservice powered by Ollama/Qwen3.

**Changes**
- src/routes/write/posts.js: Registered POST /:pid/translate route
- src/controllers/write/posts.js: Added Posts.translate controller
- src/api/posts.js: Added postsAPI.translate that calls the Flask microservice at http://localhost:5001/translate. 
- public/src/client/topic.js: Frontedn click handler for the translate button
- public/src/client/topic/postTools.js: Loading spinner while translation is in progress
- public/openapi/write/posts/pid/translate.yaml: OpenAPI schema for the new endpoint

**How it works**
- User clicks "Translate" button on a post
- Frontend sends POST /api/v3/posts:pid/translate
- NodeBB backend fetches post content and forwards it to Flask microservice
- Microservice returns translation via Ollama
- Frontend replaces post content with translation (client-side only; does not modify the database)

**How to run**
- Run the following commands:
$ ollama serve > /dev/null 2>&1 &
cd ~/llm-experiment-microservice-unpaid-interns && python3 app.py &
cd /workspaces/nodebb-spring-26-unpaid-interns && ./nodebb dev

**How to use**
- Login into NodeBB as an administrator
- Make a new post
- The translate button will show up, allowing you to click on it to get the translated text

**Result**
These are screenshots of the translate feature
<img width="1130" height="599" alt="Screenshot 2026-04-03 at 2 42 37 PM" src="https://github.com/user-attachments/assets/c92fc6ff-47cd-4d3b-a478-14d1f1f38d9d" />
<img width="1133" height="598" alt="Screenshot 2026-04-03 at 2 42 48 PM" src="https://github.com/user-attachments/assets/d54288c1-1e02-4a76-810d-6ce2975da2de" />
<img width="1134" height="595" alt="Screenshot 2026-04-03 at 2 43 00 PM" src="https://github.com/user-attachments/assets/9b8d1985-14ba-493c-8038-0c82cb9d4e6f" />
